### PR TITLE
Add dnssecValidation option to DNS configuration

### DIFF
--- a/packages/shared/src/validators/dnsConfigValidator.ts
+++ b/packages/shared/src/validators/dnsConfigValidator.ts
@@ -271,7 +271,7 @@ export const dnsConfigurationSchema = z.object({
   zones: z.array(zoneSchema).min(1, { message: 'At least one zone is required' }),
 
   // Optional advanced fields (can be added back if needed)
-  dnssecValidation: z.boolean().optional().default(true),
+  dnssecValidation: z.boolean().optional().default(false),
   queryLogging: z.boolean().optional().default(false),
 });
 

--- a/packages/shared/src/validators/dnsFormValidator.ts
+++ b/packages/shared/src/validators/dnsFormValidator.ts
@@ -74,5 +74,6 @@ export const dnsConfigSchema = z.object({
   allowRecursion: z.string(),
   forwarders: z.string(),
   allowTransfer: z.string(),
+  dnssecValidation: z.boolean().optional().default(true),
   zones: z.array(zoneSchema),
 }); 

--- a/packages/shared/src/validators/dnsTransformers.ts
+++ b/packages/shared/src/validators/dnsTransformers.ts
@@ -67,6 +67,7 @@ export const transformFormToApiData = (formData: any) => {
     allowRecursion: parseStringToArray(formData.allowRecursion),
     forwarders: parseStringToArray(formData.forwarders),
     allowTransfer: parseStringToArray(formData.allowTransfer),
+    dnssecValidation: formData.dnssecValidation,
     zones: formData.zones.map((zone: any) => ({
       id: zone.id,
       zoneName: zone.zoneName,

--- a/packages/ui/src/features/configuration/dns/DNSConfig.tsx
+++ b/packages/ui/src/features/configuration/dns/DNSConfig.tsx
@@ -549,6 +549,7 @@ export function DNSConfig() {
       allowRecursion: "localhost;",
       forwarders: "8.8.8.8; 8.8.4.4;",
       allowTransfer: "none;",
+      dnssecValidation: false,
       zones: [
         {
           id: uuidv4(),
@@ -620,6 +621,7 @@ export function DNSConfig() {
         allowRecursion: toStringArray(data.allowRecursion),
         forwarders: toStringArray(data.forwarders),
         allowTransfer: toStringArray(data.allowTransfer),
+        dnssecValidation: data.dnssecValidation,
         zones: data.zones.map(zone => ({
           id: zone.id,
           zoneName: zone.zoneName,
@@ -686,6 +688,7 @@ export function DNSConfig() {
     config += `  allow-recursion { ${values.allowRecursion} };\n`;
     config += `  forwarders { ${values.forwarders} };\n`;
     config += `  allow-transfer { ${values.allowTransfer} };\n`;
+    config += `  dnssec-validation ${values.dnssecValidation ? 'yes' : 'no'};\n`;
     config += `};\n\n`;
     
     values.zones.forEach((zone) => {
@@ -860,6 +863,28 @@ export function DNSConfig() {
                         Semicolon-separated list of IP addresses/networks allowed zone transfers
                       </FormDescription>
                       <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="dnssecValidation"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                      <div className="space-y-0.5">
+                        <FormLabel>DNSSEC Validation</FormLabel>
+                        <FormDescription>
+                          Enable DNSSEC validation for resolving queries.
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                       <FormMessage />
                     </FormItem>
                   )}
                 />


### PR DESCRIPTION
Introduce a new `dnssecValidation` option in the DNS configuration, allowing users to enable or disable DNSSEC validation. Update related forms and configurations to support this feature. Default value set to false.